### PR TITLE
Added the OS revision info + the capability to set a rule for the absolute values of the PPM settings

### DIFF
--- a/PPMCheckerTool/PPMCheckerTool/PPMSettingRules.xml
+++ b/PPMCheckerTool/PPMCheckerTool/PPMSettingRules.xml
@@ -35,6 +35,7 @@
 			<!--Frequency Cap-->
 			<setting>
 				<settingGuid> 75b0ae3f-bce0-45a7-8c89-c9611c25e100 </settingGuid>
+				<dcValue> 1500 </dcValue>
 			</setting>
 
 		</profile>


### PR DESCRIPTION
Changes: 

- Added the OS revision info. This info is required to figure out for which OS build exactly we are running the PPM validation. 
-  Added the capability to set a rule for the absolute values of the PPM settings e.g., the Scheduling policy absolute value should be = 2 (setting a min/max value is not convenient)
- Removed the method that hardcodes the PPM inversion checks. Inversion checks can be set directly in the XML file of the validation rules.