### PR TITLE
Enabled the feature to compare different settings within the same profile

### DIFF
--- a/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
+++ b/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
@@ -61,6 +61,8 @@ namespace PPMCheckerTool
         public static Guid GuidHeteroDecreaseThreshold1 = new Guid("f8861c27-95e7-475c-865b-13c0cb3f9d6c");
         public static Guid GuidHeteroIncreaseThreshold = new Guid("b000397d-9b0b-483d-98c9-692a6060cfbf");
         public static Guid GuidHeteroIncreaseThreshold1 = new Guid("b000397d-9b0b-483d-98c9-692a6060cfc0");
+        public static Guid GuidClass0Fmax = new Guid("75b0ae3f-bce0-45a7-8c89-c9611c25e100");
+        public static Guid GuidClass1Fmax = new Guid("75b0ae3f-bce0-45a7-8c89-c9611c25e101");
 
         // Current power scheme and power overlay 
         public static Guid RundownPowerScheme = Guid.Empty;
@@ -666,6 +668,11 @@ namespace PPMCheckerTool
                     else
                     {
                         // Validate against the validation rules 
+                        uint acEffectiveValue = acValue.Value;
+                        if (IsFrequencyCapSetting(settingGuid))
+                        {
+                            acEffectiveValue = uint.MaxValue;
+                        }
 
                         // Rule "acValue"
                         if (rules.acValue.HasValue)
@@ -679,7 +686,7 @@ namespace PPMCheckerTool
                         // Rule "acMinValue"
                         if (rules.acMinValue.HasValue)
                         {
-                            if (acValue.Value < rules.acMinValue.Value)
+                            if (acEffectiveValue < rules.acMinValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Setting should be >= {rules.acMinValue.Value}");
                             }
@@ -688,7 +695,7 @@ namespace PPMCheckerTool
                         // Rule "acMaxValue"
                         if (rules.acMaxValue.HasValue)
                         {
-                            if (acValue.Value > rules.acMaxValue.Value)
+                            if (acEffectiveValue > rules.acMaxValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Setting should be  <= {rules.acMaxValue.Value}");
                             }
@@ -705,7 +712,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMinDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
+                            int distanceToSetting = CalculateDistanceToSetting(acEffectiveValue, targetSettingGuid, profileGuid, true);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
@@ -729,7 +736,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMinDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acValue.Value, refProfileGuid, true);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acEffectiveValue, refProfileGuid, true);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -750,7 +757,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMaxDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
+                            int distanceToSetting = CalculateDistanceToSetting(acEffectiveValue, targetSettingGuid, profileGuid, true);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
@@ -774,7 +781,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMaxDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acValue.Value, refProfileGuid, true);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acEffectiveValue, refProfileGuid, true);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -796,6 +803,11 @@ namespace PPMCheckerTool
                     else
                     {
                         // Validate against the validation rules 
+                        uint dcEffectiveValue = dcValue.Value;
+                        if (IsFrequencyCapSetting(settingGuid))
+                        {
+                            dcEffectiveValue = uint.MaxValue;
+                        }
 
                         // Rule "dcValue"
                         if (rules.dcValue.HasValue)
@@ -809,7 +821,7 @@ namespace PPMCheckerTool
                         // Rule "dcMinValue"
                         if (rules.dcMinValue.HasValue)
                         {
-                            if (dcValue.Value < rules.dcMinValue.Value)
+                            if (dcEffectiveValue < rules.dcMinValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Setting should be >= {rules.dcMinValue.Value}");
                             }
@@ -818,7 +830,7 @@ namespace PPMCheckerTool
                         // Rule "dcMaxValue"
                         if (rules.dcMaxValue.HasValue)
                         {
-                            if (dcValue.Value > rules.dcMaxValue.Value)
+                            if (dcEffectiveValue > rules.dcMaxValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Setting should be  <= {rules.dcMaxValue.Value}");
                             }
@@ -835,7 +847,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMinDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
+                            int distanceToSetting = CalculateDistanceToSetting(dcEffectiveValue, targetSettingGuid, profileGuid, false);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
@@ -859,7 +871,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMinDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcValue.Value, refProfileGuid, false);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcEffectiveValue, refProfileGuid, false);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -880,7 +892,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMaxDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
+                            int distanceToSetting = CalculateDistanceToSetting(dcEffectiveValue, targetSettingGuid, profileGuid, false);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
@@ -904,7 +916,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMaxDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcValue.Value, refProfileGuid, false);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcEffectiveValue, refProfileGuid, false);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -1289,6 +1301,18 @@ namespace PPMCheckerTool
                     settingGuid == GuidHeteroDecreaseThreshold1 ||
                     settingGuid == GuidHeteroIncreaseThreshold ||
                     settingGuid == GuidHeteroIncreaseThreshold1);
+        }
+
+        /// <summary>
+        /// Helper function 
+        /// Verify if a setting is one of the settings to cap the frequency
+        /// </summary>
+        /// <param name="settingGuid"> GUID of the setting</param>
+        /// <returns> True is the setting is a frequency cap setting </returns>
+        static bool IsFrequencyCapSetting(Guid settingGuid)
+        {
+            return (settingGuid == GuidClass0Fmax ||
+                    settingGuid == GuidClass1Fmax);
         }
 
         /// <summary>

--- a/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
+++ b/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
@@ -73,6 +73,9 @@ namespace PPMCheckerTool
         // Default Overlay Scheme name
         public const String DefaultOverlayScheme = "OEM Default Overlay Scheme";
 
+        // Fmax
+        public const uint FMAX = 100000;
+
         // Validation rules associated with each PPM setting
         public struct SettingValidationRules
         {
@@ -668,10 +671,11 @@ namespace PPMCheckerTool
                     else
                     {
                         // Validate against the validation rules 
-                        uint acEffectiveValue = acValue.Value;
-                        if (IsFrequencyCapSetting(settingGuid))
+
+                        // Case of Fmax = 0
+                        if (IsFrequencyCapSetting(settingGuid) && acValue.Value == 0)
                         {
-                            acEffectiveValue = uint.MaxValue;
+                            acValue = FMAX;
                         }
 
                         // Rule "acValue"
@@ -686,7 +690,7 @@ namespace PPMCheckerTool
                         // Rule "acMinValue"
                         if (rules.acMinValue.HasValue)
                         {
-                            if (acEffectiveValue < rules.acMinValue.Value)
+                            if (acValue.Value < rules.acMinValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Setting should be >= {rules.acMinValue.Value}");
                             }
@@ -695,7 +699,7 @@ namespace PPMCheckerTool
                         // Rule "acMaxValue"
                         if (rules.acMaxValue.HasValue)
                         {
-                            if (acEffectiveValue > rules.acMaxValue.Value)
+                            if (acValue.Value > rules.acMaxValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Setting should be  <= {rules.acMaxValue.Value}");
                             }
@@ -712,7 +716,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMinDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(acEffectiveValue, targetSettingGuid, profileGuid, true);
+                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
@@ -720,7 +724,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToSetting < distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Actual distance = {distanceToSetting}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}.");
                             }
                         }
 
@@ -736,7 +740,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMinDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acEffectiveValue, refProfileGuid, true);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acValue.Value, refProfileGuid, true);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -744,7 +748,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToRefProfile < distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to profile {refProfileName} should be >= {distance}. Actual distance = {distanceToRefProfile}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to profile {refProfileName} should be >= {distance}.");
                             }
                         }
 
@@ -757,7 +761,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMaxDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(acEffectiveValue, targetSettingGuid, profileGuid, true);
+                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
@@ -765,7 +769,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToSetting > distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Actual distance = {distanceToSetting}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}.");
                             }
                         }
 
@@ -781,7 +785,7 @@ namespace PPMCheckerTool
                             int distance = rules.acMaxDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acEffectiveValue, refProfileGuid, true);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, acValue.Value, refProfileGuid, true);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -789,7 +793,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToRefProfile > distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to profile {refProfileName} should be <= {distance}. Actual distance = {distanceToRefProfile}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to profile {refProfileName} should be <= {distance}.");
                             }
                         }
                     }
@@ -803,10 +807,11 @@ namespace PPMCheckerTool
                     else
                     {
                         // Validate against the validation rules 
-                        uint dcEffectiveValue = dcValue.Value;
-                        if (IsFrequencyCapSetting(settingGuid))
+
+                        // Case of Fmax = 0
+                        if (IsFrequencyCapSetting(settingGuid) && dcValue.Value == 0)
                         {
-                            dcEffectiveValue = uint.MaxValue;
+                            dcValue = FMAX;
                         }
 
                         // Rule "dcValue"
@@ -821,7 +826,7 @@ namespace PPMCheckerTool
                         // Rule "dcMinValue"
                         if (rules.dcMinValue.HasValue)
                         {
-                            if (dcEffectiveValue < rules.dcMinValue.Value)
+                            if (dcValue.Value < rules.dcMinValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Setting should be >= {rules.dcMinValue.Value}");
                             }
@@ -830,7 +835,7 @@ namespace PPMCheckerTool
                         // Rule "dcMaxValue"
                         if (rules.dcMaxValue.HasValue)
                         {
-                            if (dcEffectiveValue > rules.dcMaxValue.Value)
+                            if (dcValue.Value > rules.dcMaxValue.Value)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Setting should be  <= {rules.dcMaxValue.Value}");
                             }
@@ -847,7 +852,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMinDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(dcEffectiveValue, targetSettingGuid, profileGuid, false);
+                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
@@ -855,7 +860,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToSetting < distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Actual distance = {distanceToSetting}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}.");
                             }
                         }
 
@@ -871,7 +876,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMinDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcEffectiveValue, refProfileGuid, false);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcValue.Value, refProfileGuid, false);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -879,7 +884,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToRefProfile < distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to profile {refProfileName} should be >= {distance}. Actual distance = {distanceToRefProfile}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to profile {refProfileName} should be >= {distance}.");
                             }
                         }
 
@@ -892,7 +897,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMaxDistanceToSetting.Item2;
 
                             // Calculate the distance to the target setting
-                            int distanceToSetting = CalculateDistanceToSetting(dcEffectiveValue, targetSettingGuid, profileGuid, false);
+                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
                             if (distanceToSetting == Int32.MinValue)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
@@ -900,7 +905,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToSetting > distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Actual distance = {distanceToSetting}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}.");
                             }
                         }
 
@@ -916,7 +921,7 @@ namespace PPMCheckerTool
                             int distance = rules.dcMaxDistanceToProfile.Item2;
 
                             // Calculate the distance to reference profile
-                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcEffectiveValue, refProfileGuid, false);
+                            int distanceToRefProfile = CalculateDistanceToProfile(settingGuid, dcValue.Value, refProfileGuid, false);
 
                             if (distanceToRefProfile == Int32.MinValue)
                             {
@@ -924,7 +929,7 @@ namespace PPMCheckerTool
                             }
                             else if (distanceToRefProfile > distance)
                             {
-                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to profile {refProfileName} should be <= {distance}. Actual distance = {distanceToRefProfile}");
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to profile {refProfileName} should be <= {distance}.");
                             }
                         }
                     }
@@ -1160,9 +1165,15 @@ namespace PPMCheckerTool
                 }
             }
 
-            // Check we found a value for the setting that will use to measure the distance
+            // Check if we found a value for the setting that will use to measure the distance
             if (targetSettingValue.HasValue)
             {
+                // Case of Fmax = 0
+                if (IsFrequencyCapSetting(targetSettingGuid) && targetSettingValue.Value == 0)
+                {
+                    targetSettingValue = FMAX;
+                }
+
                 // Calculate the distance between the two settings 
                 int distance = (int)settingValue - (int)targetSettingValue.Value;
                 return distance;
@@ -1224,6 +1235,12 @@ namespace PPMCheckerTool
             if (!refProfileSettingValue.HasValue)
             {
                 return Int32.MinValue;
+            }
+
+            // Case of Fmax = 0
+            if(IsFrequencyCapSetting(settingGuid) && refProfileSettingValue.Value == 0)
+            {
+                refProfileSettingValue = FMAX;
             }
 
             // Calculate the distance to Ref profile 

--- a/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
+++ b/PPMCheckerTool/PPMCheckerTool/PPMCheckerTool.cs
@@ -86,10 +86,20 @@ namespace PPMCheckerTool
             public uint? acMaxValue;
             public uint? dcMaxValue;
 
+            // Min distance to another setting in the same profile
+            // Pair (Setting Guid, MinDistance)
+            public Tuple<Guid, int> acMinDistanceToSetting;
+            public Tuple<Guid, int> dcMinDistanceToSetting;
+
             // Min distance to the setting of another profile
             // Pair (Profile Guid, MinDistance)
             public Tuple<Guid, int> acMinDistanceToProfile;
             public Tuple<Guid, int> dcMinDistanceToProfile;
+
+            // Min distance to another setting in the same profile
+            // Pair (Setting Guid, MinDistance)
+            public Tuple<Guid, int> acMaxDistanceToSetting;
+            public Tuple<Guid, int> dcMaxDistanceToSetting;
 
             // Max distance to the setting of another profile
             // Pair (Profile Guid, MaxDistance)
@@ -684,6 +694,29 @@ namespace PPMCheckerTool
                             }
                         }
 
+                        // Rule acMinDistanceToSetting
+                        if (rules.acMinDistanceToSetting != null)
+                        {
+                            Guid targetSettingGuid = rules.acMinDistanceToSetting.Item1;
+                            string targetSettingName;
+                            GuidToFriendlyName.TryGetValue(targetSettingGuid, out targetSettingName);
+
+                            // Get the distance value
+                            int distance = rules.acMinDistanceToSetting.Item2;
+
+                            // Calculate the distance to the target setting
+                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
+                            if (distanceToSetting == Int32.MinValue)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
+
+                            }
+                            else if (distanceToSetting < distance)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Actual distance = {distanceToSetting}");
+                            }
+                        }
+
                         // Rule "acMinDistanceToProfile"
                         if (rules.acMinDistanceToProfile != null)
                         {
@@ -705,6 +738,27 @@ namespace PPMCheckerTool
                             else if (distanceToRefProfile < distance)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to profile {refProfileName} should be >= {distance}. Actual distance = {distanceToRefProfile}");
+                            }
+                        }
+
+                        // Rule acMaxDistanceToSetting
+                        if (rules.acMaxDistanceToSetting != null)
+                        {
+                            Guid targetSettingGuid = rules.acMaxDistanceToSetting.Item1;
+                            string targetSettingName;
+                            GuidToFriendlyName.TryGetValue(targetSettingGuid, out targetSettingName);
+                            int distance = rules.acMaxDistanceToSetting.Item2;
+
+                            // Calculate the distance to the target setting
+                            int distanceToSetting = CalculateDistanceToSetting(acValue.Value, targetSettingGuid, profileGuid, true);
+                            if (distanceToSetting == Int32.MinValue)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
+
+                            }
+                            else if (distanceToSetting > distance)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , AC , {acValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Actual distance = {distanceToSetting}");
                             }
                         }
 
@@ -770,6 +824,29 @@ namespace PPMCheckerTool
                             }
                         }
 
+                        // Rule dcMinDistanceToSetting
+                        if (rules.dcMinDistanceToSetting != null)
+                        {
+                            Guid targetSettingGuid = rules.dcMinDistanceToSetting.Item1;
+                            string targetSettingName;
+                            GuidToFriendlyName.TryGetValue(targetSettingGuid, out targetSettingName);
+
+                            // Get the distance value
+                            int distance = rules.dcMinDistanceToSetting.Item2;
+
+                            // Calculate the distance to the target setting
+                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
+                            if (distanceToSetting == Int32.MinValue)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Setting {targetSettingName} was not set");
+
+                            }
+                            else if (distanceToSetting < distance)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be >= {distance}. Actual distance = {distanceToSetting}");
+                            }
+                        }
+
                         // Rule "dcMinDistanceToProfile"
                         if (rules.dcMinDistanceToProfile != null)
                         {
@@ -791,6 +868,27 @@ namespace PPMCheckerTool
                             else if (distanceToRefProfile < distance)
                             {
                                 Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to profile {refProfileName} should be >= {distance}. Actual distance = {distanceToRefProfile}");
+                            }
+                        }
+
+                        // Rule dcMaxDistanceToSetting
+                        if (rules.dcMaxDistanceToSetting != null)
+                        {
+                            Guid targetSettingGuid = rules.dcMaxDistanceToSetting.Item1;
+                            string targetSettingName;
+                            GuidToFriendlyName.TryGetValue(targetSettingGuid, out targetSettingName);
+                            int distance = rules.dcMaxDistanceToSetting.Item2;
+
+                            // Calculate the distance to the target setting
+                            int distanceToSetting = CalculateDistanceToSetting(dcValue.Value, targetSettingGuid, profileGuid, false);
+                            if (distanceToSetting == Int32.MinValue)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Setting {targetSettingName} was not set");
+
+                            }
+                            else if (distanceToSetting > distance)
+                            {
+                                Results.Add($"ERROR , {profileName} , {settingName} , DC , {dcValue.Value} , Distance to setting {targetSettingName} should be <= {distance}. Actual distance = {distanceToSetting}");
                             }
                         }
 
@@ -1009,6 +1107,58 @@ namespace PPMCheckerTool
                 }
             }
         }
+
+        /// <summary>
+        /// Calculate the distance between two different settings  
+        /// The two settings should be in the same profile
+        /// E.g. Fmax for P-cores, vs. Fmax for E-cores
+        /// </summary>
+        /// <param name="settingValue"> Value the first setting </param>
+        /// <param name="targetSettingGuid"> The setting's guid that we will use to measure the distance </param>
+        /// <param name="profileGuid"> GUID of the profile of the two settings</param>
+        /// <param name="isAC"> AC/DC mode </param>
+        /// <returns> the distance between the two settings or Int32.MinValue </returns>
+        public static int CalculateDistanceToSetting(uint settingValue, Guid targetSettingGuid, Guid profileGuid, bool isAC)
+        {
+            // Get the value of the setting that we will use to measure the distance
+            var profileId = ProfileNames.FirstOrDefault(x => x.Value.Item3 == profileGuid).Key;
+
+            uint? targetSettingValue = null;
+
+            if (PowSettings.ContainsKey(targetSettingGuid))
+            {
+                if (PowSettings[targetSettingGuid].ContainsKey(profileId))
+                {
+                    if (isAC)
+                    {
+                        targetSettingValue = PowSettings[targetSettingGuid][profileId].Item1;
+                    }
+                    else
+                    {
+                        targetSettingValue = PowSettings[targetSettingGuid][profileId].Item2;
+                    }
+                }
+                else
+                {
+                    // The setting was not set for the profileGuid 
+                    // Check if profileGuid inherits the settings from another profile
+
+                    Guid? refProfileParentGuid = null;
+                    FindSettingInParentProfiles(isAC, profileGuid, targetSettingGuid, ref refProfileParentGuid, ref targetSettingValue);
+                }
+            }
+
+            // Check we found a value for the setting that will use to measure the distance
+            if (targetSettingValue.HasValue)
+            {
+                // Calculate the distance between the two settings 
+                int distance = (int)settingValue - (int)targetSettingValue.Value;
+                return distance;
+            }
+
+            return Int32.MinValue;
+        }
+
 
         /// <summary>
         /// For a given setting, calculate the distance between two different profiles 
@@ -1303,6 +1453,20 @@ namespace PPMCheckerTool
                 }
             }
 
+            // Min Distance to another setting in AC mode
+            if (settingNode["AcMinDistanceToSetting"] != null)
+            {
+                if (settingNode["AcMinDistanceToSetting"]["Setting"] != null && settingNode["AcMinDistanceToSetting"]["Distance"] != null)
+                {
+                    String refSettingeName = settingNode["AcMinDistanceToSetting"]["Setting"].InnerText.Replace(" ", "");
+                    Guid refSettingGuid;
+                    FriendlyNameToGuid.TryGetValue(refSettingeName, out refSettingGuid);
+
+                    int distance = Convert.ToInt32(settingNode["AcMinDistanceToSetting"]["Distance"].InnerText);
+                    settingValidationRules.acMinDistanceToSetting = new Tuple<Guid, int>(refSettingGuid, distance);
+                }
+            }
+
             // Max Distance to profile in AC mode
             if (settingNode["AcMaxDistanceToProfile"] != null)
             {
@@ -1314,6 +1478,20 @@ namespace PPMCheckerTool
 
                     int distance = Convert.ToInt32(settingNode["AcMaxDistanceToProfile"]["Distance"].InnerText);
                     settingValidationRules.acMaxDistanceToProfile = new Tuple<Guid, int>(refProfileGuid, distance);
+                }
+            }
+
+            // Max Distance to another setting in AC mode
+            if (settingNode["AcMaxDistanceToSetting"] != null)
+            {
+                if (settingNode["AcMaxDistanceToSetting"]["Setting"] != null && settingNode["AcMaxDistanceToSetting"]["Distance"] != null)
+                {
+                    String refSettingeName = settingNode["AcMaxDistanceToSetting"]["Setting"].InnerText.Replace(" ", "");
+                    Guid refSettingGuid;
+                    FriendlyNameToGuid.TryGetValue(refSettingeName, out refSettingGuid);
+
+                    int distance = Convert.ToInt32(settingNode["AcMaxDistanceToSetting"]["Distance"].InnerText);
+                    settingValidationRules.acMaxDistanceToSetting = new Tuple<Guid, int>(refSettingGuid, distance);
                 }
             }
 
@@ -1349,6 +1527,20 @@ namespace PPMCheckerTool
                 }
             }
 
+            // Min Distance to another setting in DC mode
+            if (settingNode["DcMinDistanceToSetting"] != null)
+            {
+                if (settingNode["DcMinDistanceToSetting"]["Setting"] != null && settingNode["DcMinDistanceToSetting"]["Distance"] != null)
+                {
+                    String refSettingeName = settingNode["DcMinDistanceToSetting"]["Setting"].InnerText.Replace(" ", "");
+                    Guid refSettingGuid;
+                    FriendlyNameToGuid.TryGetValue(refSettingeName, out refSettingGuid);
+
+                    int distance = Convert.ToInt32(settingNode["DcMinDistanceToSetting"]["Distance"].InnerText);
+                    settingValidationRules.dcMinDistanceToSetting = new Tuple<Guid, int>(refSettingGuid, distance);
+                }
+            }
+
             // Max Distance to profile in DC mode
             if (settingNode["DcMaxDistanceToProfile"] != null)
             {
@@ -1360,6 +1552,20 @@ namespace PPMCheckerTool
 
                     int distance = Convert.ToInt32(settingNode["DcMaxDistanceToProfile"]["Distance"].InnerText);
                     settingValidationRules.dcMaxDistanceToProfile = new Tuple<Guid, int>(refProfileGuid, distance);
+                }
+            }
+
+            // Max Distance to another setting in DC mode
+            if (settingNode["DcMaxDistanceToSetting"] != null)
+            {
+                if (settingNode["DcMaxDistanceToSetting"]["Setting"] != null && settingNode["DcMaxDistanceToSetting"]["Distance"] != null)
+                {
+                    String refSettingeName = settingNode["DcMaxDistanceToSetting"]["Setting"].InnerText.Replace(" ", "");
+                    Guid refSettingGuid;
+                    FriendlyNameToGuid.TryGetValue(refSettingeName, out refSettingGuid);
+
+                    int distance = Convert.ToInt32(settingNode["DcMaxDistanceToSetting"]["Distance"].InnerText);
+                    settingValidationRules.dcMaxDistanceToSetting = new Tuple<Guid, int>(refSettingGuid, distance);
                 }
             }
 

--- a/PPMCheckerTool/PPMCheckerTool/PPMSettingRules.xml
+++ b/PPMCheckerTool/PPMCheckerTool/PPMSettingRules.xml
@@ -53,7 +53,27 @@
 					<DcMaxValue> 1500 </DcMaxValue>
 				</Setting>
 
-			
+				<!--Class1 Fmax should be >= Class0 Fmax-->
+				<Setting name="PROCFREQMAX1">
+
+					<DcMinDistanceToSetting>
+						<Setting> PROCFREQMAX </Setting>
+						<Distance> 0 </Distance>
+					</DcMinDistanceToSetting>
+				</Setting>
+			</Profile>
+
+			<!--LowQoS profile-->
+			<Profile name="Profile_LowQos">
+				
+				<!--Class1 Fmax should be >= Class0 Fmax-->
+				<Setting name="PROCFREQMAX1">
+
+					<DcMinDistanceToSetting>
+						<Setting> PROCFREQMAX </Setting>
+						<Distance> 0 </Distance>
+					</DcMinDistanceToSetting>
+				</Setting>
 			</Profile>
 
 		</Overlay>


### PR DESCRIPTION
This PR allows the ability to compare different settings within the same profile. This is necessary to avoid the inversions between cores classes. For example, Class 1 cores Fmax should be higher than Class0 cores Fmax. To ensure this rule we need to compare the class0 Fmax setting with class0 Fmax.